### PR TITLE
Add flush to assertion headers

### DIFF
--- a/tools/testest/testest.factor
+++ b/tools/testest/testest.factor
@@ -4,8 +4,8 @@ USING: accessors continuations debugger formatting fry io io.styles kernel local
 namespaces parser prettyprint prettyprint.config quotations sequences system ;
 IN: tools.testest
 
-: describe#{ ( description -- starttime ) nl "<DESCRIBE::>%s" printf nl nano-count ;
-: it#{ ( description -- starttime ) nl "<IT::>%s" printf nl nano-count ;
+: describe#{ ( description -- starttime ) nl "<DESCRIBE::>%s" printf nl flush nano-count ;
+: it#{ ( description -- starttime ) nl "<IT::>%s" printf nl flush nano-count ;
 : }# ( starttime -- ) nano-count swap - 1000000 / nl "<COMPLETEDIN::>%f ms" printf nl ;
 
 ! line internal unformatted linefeed, to be used in single-line test result messages


### PR DESCRIPTION
Adds `flush` to both `describe#{` and `it#{` words, to ensure that all assertions are displayed properly on timeout.

Before (current behaviour):
<img width="480" alt="Screen Shot 2022-06-27 at 9 21 58 231 am" src="https://user-images.githubusercontent.com/43819332/175882614-a2fb3ef0-ee7d-434a-a38d-c2863c3e3a6c.png">

After:

<img width="483" alt="Screen Shot 2022-06-27 at 9 23 04 655 am" src="https://user-images.githubusercontent.com/43819332/175882831-fcfe3536-2532-48d2-8274-628bb525f311.png">