### PR TITLE
Only use solution word from kata to prevent potential name clashes from user code

### DIFF
--- a/example/kata/tests/tests.factor
+++ b/example/kata/tests/tests.factor
@@ -1,4 +1,5 @@
-USING: kata.preloaded kata prettyprint tools.testest ;
+USING: kata.preloaded prettyprint tools.testest ;
+FROM: kata => solution ;
 IN: kata.tests
 
 : run-tests ( -- )


### PR DESCRIPTION
Example code shows `USING: ... kata ... ` in test code, which imports all words defined by the user, including potential name clashes with import in the test code. To prevent any potential name clashes, restrict the import to the words under test only.