### PR TITLE
Reformat output of seq.

### DIFF
--- a/test/test-custom.expected
+++ b/test/test-custom.expected
@@ -27,9 +27,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Actually expected :<:LF:>"Hello Worlds!"<:LF:>but instead got :<:LF:>"Hello World!"
+<FAILED::>Actually expected :<:LF:>  "Hello Worlds!"<:LF:>but instead got :<:LF:>  "Hello World!"
 
-<FAILED::>Actually expected :<:LF:>"Hello Worlds! "<:LF:>but instead got :<:LF:>"Hello Worlds!"
+<FAILED::>Actually expected :<:LF:>  "Hello Worlds! "<:LF:>but instead got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.162660 ms
 
@@ -43,9 +43,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Test Failed : Actually expected :<:LF:>"Hello Worlds!"<:LF:>but instead got :<:LF:>"Hello World!"
+<FAILED::>Test Failed : Actually expected :<:LF:>  "Hello Worlds!"<:LF:>but instead got :<:LF:>  "Hello World!"
 
-<FAILED::>Test Failed : Actually expected :<:LF:>"Hello Worlds! "<:LF:>but instead got :<:LF:>"Hello Worlds!"
+<FAILED::>Test Failed : Actually expected :<:LF:>  "Hello Worlds! "<:LF:>but instead got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.055392 ms
 

--- a/test/test-expected-actual.expected
+++ b/test/test-expected-actual.expected
@@ -9,7 +9,7 @@
 
 <IT::>Mismatch
 
-<FAILED::>Test Failed : Expected :<:LF:>4<:LF:>5<:LF:>6<:LF:>7<:LF:>but got :<:LF:>0<:LF:>1<:LF:>2<:LF:>3
+<FAILED::>Test Failed : Expected :<:LF:>  4<:LF:>  5<:LF:>  6<:LF:>  7<:LF:>but got :<:LF:>  0<:LF:>  1<:LF:>  2<:LF:>  3
 
 <COMPLETEDIN::>0.126585 ms
 

--- a/test/test-expected-actual.expected
+++ b/test/test-expected-actual.expected
@@ -9,7 +9,7 @@
 
 <IT::>Mismatch
 
-<FAILED::>Test Failed : Expected :<:LF:>  4<:LF:>  5<:LF:>  6<:LF:>  7<:LF:>but got :<:LF:>  0<:LF:>  1<:LF:>  2<:LF:>  3
+<FAILED::>Test Failed : Expected :<:LF:>  4<:LF:>  5<:LF:>  6<:LF:>  7<:LF:>But got :<:LF:>  0<:LF:>  1<:LF:>  2<:LF:>  3
 
 <COMPLETEDIN::>0.126585 ms
 

--- a/test/test-fail.expected
+++ b/test/test-fail.expected
@@ -1,2 +1,2 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>  1<:LF:>but got :<:LF:>  0
+<FAILED::>Test Failed : Expected :<:LF:>  1<:LF:>But got :<:LF:>  0

--- a/test/test-fail.expected
+++ b/test/test-fail.expected
@@ -1,2 +1,2 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>1<:LF:>but got :<:LF:>0
+<FAILED::>Test Failed : Expected :<:LF:>  1<:LF:>but got :<:LF:>  0

--- a/test/test-sequences.expected
+++ b/test/test-sequences.expected
@@ -1,4 +1,4 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>{ 1 }<:LF:>but got :<:LF:>{ 0 }
+<FAILED::>Test Failed : Expected :<:LF:>  { 1 }<:LF:>but got :<:LF:>  { 0 }
 
-<FAILED::>Test Failed : Expected :<:LF:>{ { 0 } { 1 } }<:LF:>but got :<:LF:>{ { 0 } { 0 } }
+<FAILED::>Test Failed : Expected :<:LF:>  { { 0 } { 1 } }<:LF:>but got :<:LF:>  { { 0 } { 0 } }

--- a/test/test-sequences.expected
+++ b/test/test-sequences.expected
@@ -1,4 +1,4 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>  { 1 }<:LF:>but got :<:LF:>  { 0 }
+<FAILED::>Test Failed : Expected :<:LF:>  { 1 }<:LF:>But got :<:LF:>  { 0 }
 
-<FAILED::>Test Failed : Expected :<:LF:>  { { 0 } { 1 } }<:LF:>but got :<:LF:>  { { 0 } { 0 } }
+<FAILED::>Test Failed : Expected :<:LF:>  { { 0 } { 1 } }<:LF:>But got :<:LF:>  { { 0 } { 0 } }

--- a/test/test-stack-mismatch.expected
+++ b/test/test-stack-mismatch.expected
@@ -3,13 +3,13 @@
 
 <IT::>single test
 
-<FAILED::>Test Failed : Expected :<:LF:>0<:LF:>but got :<:LF:>0<:LF:>0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0
 
 <COMPLETEDIN::>0.126526 ms
 
 <IT::>double test
 
-<FAILED::>Test Failed : Expected :<:LF:>0<:LF:>but got :<:LF:>0<:LF:>0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0
 
 <PASSED::>Test Passed
 
@@ -17,9 +17,9 @@
 
 <IT::>double fail test
 
-<FAILED::>Test Failed : Expected :<:LF:>0<:LF:>but got :<:LF:>0<:LF:>0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0
 
-<FAILED::>Test Failed : Expected :<:LF:>0<:LF:>0<:LF:>0<:LF:>but got :<:LF:>0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>  0<:LF:>  0<:LF:>but got :<:LF:>  0
 
 <COMPLETEDIN::>0.030305 ms
 

--- a/test/test-stack-mismatch.expected
+++ b/test/test-stack-mismatch.expected
@@ -3,13 +3,13 @@
 
 <IT::>single test
 
-<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>But got :<:LF:>  0<:LF:>  0
 
 <COMPLETEDIN::>0.126526 ms
 
 <IT::>double test
 
-<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>But got :<:LF:>  0<:LF:>  0
 
 <PASSED::>Test Passed
 
@@ -17,9 +17,9 @@
 
 <IT::>double fail test
 
-<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>But got :<:LF:>  0<:LF:>  0
 
-<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>  0<:LF:>  0<:LF:>but got :<:LF:>  0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>  0<:LF:>  0<:LF:>But got :<:LF:>  0
 
 <COMPLETEDIN::>0.030305 ms
 

--- a/test/test-too-little-arguments.expected
+++ b/test/test-too-little-arguments.expected
@@ -1,2 +1,2 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>0<:LF:>0<:LF:>but got :<:LF:>0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>  0<:LF:>but got :<:LF:>  0

--- a/test/test-too-little-arguments.expected
+++ b/test/test-too-little-arguments.expected
@@ -1,2 +1,2 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>  0<:LF:>but got :<:LF:>  0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>  0<:LF:>But got :<:LF:>  0

--- a/test/test-too-many-arguments.expected
+++ b/test/test-too-many-arguments.expected
@@ -1,2 +1,2 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>But got :<:LF:>  0<:LF:>  0

--- a/test/test-too-many-arguments.expected
+++ b/test/test-too-many-arguments.expected
@@ -1,2 +1,2 @@
 
-<FAILED::>Test Failed : Expected :<:LF:>0<:LF:>but got :<:LF:>0<:LF:>0
+<FAILED::>Test Failed : Expected :<:LF:>  0<:LF:>but got :<:LF:>  0<:LF:>  0

--- a/test/test-with-passed-failed.expected
+++ b/test/test-with-passed-failed.expected
@@ -27,9 +27,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Expected :<:LF:>  "Hello Worlds!"<:LF:>but got :<:LF:>  "Hello World!"
+<FAILED::>Expected :<:LF:>  "Hello Worlds!"<:LF:>But got :<:LF:>  "Hello World!"
 
-<FAILED::>Expected :<:LF:>  "Hello Worlds! "<:LF:>but got :<:LF:>  "Hello Worlds!"
+<FAILED::>Expected :<:LF:>  "Hello Worlds! "<:LF:>But got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.131308 ms
 
@@ -43,9 +43,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Test Failed : Expected :<:LF:>  "Hello Worlds!"<:LF:>but got :<:LF:>  "Hello World!"
+<FAILED::>Test Failed : Expected :<:LF:>  "Hello Worlds!"<:LF:>But got :<:LF:>  "Hello World!"
 
-<FAILED::>Test Failed : Expected :<:LF:>  "Hello Worlds! "<:LF:>but got :<:LF:>  "Hello Worlds!"
+<FAILED::>Test Failed : Expected :<:LF:>  "Hello Worlds! "<:LF:>But got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.060291 ms
 
@@ -63,9 +63,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Test failed A Expected :<:LF:>  "Hello Worlds!"<:LF:>but got :<:LF:>  "Hello World!"
+<FAILED::>Test failed A Expected :<:LF:>  "Hello Worlds!"<:LF:>But got :<:LF:>  "Hello World!"
 
-<FAILED::>Test failed A Expected :<:LF:>  "Hello Worlds! "<:LF:>but got :<:LF:>  "Hello Worlds!"
+<FAILED::>Test failed A Expected :<:LF:>  "Hello Worlds! "<:LF:>But got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.044357 ms
 

--- a/test/test-with-passed-failed.expected
+++ b/test/test-with-passed-failed.expected
@@ -27,9 +27,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Expected :<:LF:>"Hello Worlds!"<:LF:>but got :<:LF:>"Hello World!"
+<FAILED::>Expected :<:LF:>  "Hello Worlds!"<:LF:>but got :<:LF:>  "Hello World!"
 
-<FAILED::>Expected :<:LF:>"Hello Worlds! "<:LF:>but got :<:LF:>"Hello Worlds!"
+<FAILED::>Expected :<:LF:>  "Hello Worlds! "<:LF:>but got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.131308 ms
 
@@ -43,9 +43,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Test Failed : Expected :<:LF:>"Hello Worlds!"<:LF:>but got :<:LF:>"Hello World!"
+<FAILED::>Test Failed : Expected :<:LF:>  "Hello Worlds!"<:LF:>but got :<:LF:>  "Hello World!"
 
-<FAILED::>Test Failed : Expected :<:LF:>"Hello Worlds! "<:LF:>but got :<:LF:>"Hello Worlds!"
+<FAILED::>Test Failed : Expected :<:LF:>  "Hello Worlds! "<:LF:>but got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.060291 ms
 
@@ -63,9 +63,9 @@
 
 <IT::>failing compares
 
-<FAILED::>Test failed A Expected :<:LF:>"Hello Worlds!"<:LF:>but got :<:LF:>"Hello World!"
+<FAILED::>Test failed A Expected :<:LF:>  "Hello Worlds!"<:LF:>but got :<:LF:>  "Hello World!"
 
-<FAILED::>Test failed A Expected :<:LF:>"Hello Worlds! "<:LF:>but got :<:LF:>"Hello Worlds!"
+<FAILED::>Test failed A Expected :<:LF:>  "Hello Worlds! "<:LF:>but got :<:LF:>  "Hello Worlds!"
 
 <COMPLETEDIN::>0.044357 ms
 

--- a/tools/testest/testest.factor
+++ b/tools/testest/testest.factor
@@ -70,5 +70,5 @@ M: tuple error. dup class-of error-class? [ pprint-short ] [ describe ] if ;
 
 M: assert-sequence error.
   [ "Expected :" write expected>> seq. ]
-  [ nl "but got :" write got>> seq. ] bi
+  [ nl "But got :" write got>> seq. ] bi
 ;

--- a/tools/testest/testest.factor
+++ b/tools/testest/testest.factor
@@ -55,7 +55,7 @@ SYNTAX: <{ \ -> parse-until >quotation suffix! \ }> parse-until >quotation suffi
 
 : seq. ( seq -- )
   [
-    [ nl pprint-unlimited ]
+    [ nl bl bl pprint-unlimited ]
     [ drop [ error-in-pprint ] keep write-object ]
     recover
   ] each


### PR DESCRIPTION
Adapt output of `seq.` to prepend 2 spaces before each item in the sequence to enhance readability