### PR TITLE
Keep timestamps off stack (Fix #41)

### DIFF
--- a/tools/testest/testest.factor
+++ b/tools/testest/testest.factor
@@ -5,9 +5,16 @@ io io.streams.string io.styles kernel locals math namespaces parser prettyprint 
 prettyprint.config prettyprint.custom quotations sequences splitting system ;
 IN: tools.testest
 
-: describe#{ ( description -- starttime ) nl "<DESCRIBE::>%s" printf nl flush nano-count ;
-: it#{ ( description -- starttime ) nl "<IT::>%s" printf nl flush nano-count ;
-: }# ( starttime -- ) nano-count swap - 1000000 / nl "<COMPLETEDIN::>%f ms" printf nl ;
+DEFER: }# delimiter
+: timed-block ( accum tag -- accum )
+  \ }# parse-until >quotation '[
+     nl _ printf nl flush nano-count _ dip
+     nano-count swap - 1000000 / nl "<COMPLETEDIN::>%f ms" printf nl
+  ] append! ;
+
+SYNTAX: describe#{ "<DESCRIBE::>%s" timed-block ;
+SYNTAX: it#{ "<IT::>%s" timed-block ;
+
 
 ! user redefinable test result message quotations
 


### PR DESCRIPTION
Removes timestamps from the stack for `it#{` and `describe#{` blocks, keeping them instead in the retain stack, inaccessible to user code. Since timestamps are an implementation detail and can cause unexpected behaviour, I believe it is an important change.

Note that this was tested against the existing 0.98 version, it is possible (though I doubt it) that it may require modifications for 0.99.

Edits and feedback are of course welcome.