### PR TITLE
On compiler errors prevent running tests and report errors

### DIFF
--- a/test/test-compilation-error.expected
+++ b/test/test-compilation-error.expected
@@ -1,0 +1,29 @@
+test-compilation-error.factor
+
+6: : wont-compile ;
+                   ^
+Expected ( but got ;
+(U) Quotation: [ c-to-factor => ]
+    Word: c-to-factor
+(U) Quotation: [ [ (get-catchstack) push ] dip call => (get-catchstack) pop* ]
+(O) Word: command-line-startup
+(O) Word: run-script
+(O) Word: run-file
+(O) Word: parse-file
+(O) Word: parse-stream
+(O) Word: parse-fresh
+(O) Word: (parse-lines)
+(O) Word: (parse-until)
+(O) Word: parse-until-step
+(O) Word: execute-parsing
+(O) Word: POSTPONE: :
+(O) Word: (:)
+(O) Word: scan-effect
+(O) Word: expect
+(O) Word: unexpected
+(O) Method: M\ object throw
+(U) Quotation: [
+        OBJ-CURRENT-THREAD special-object error-thread set-global
+        current-continuation => error-continuation set-global
+        [ original-error set-global ] [ rethrow ] bi
+    ]

--- a/test/test-compilation-error.factor
+++ b/test/test-compilation-error.factor
@@ -1,0 +1,17 @@
+! Copyright 2024 nomennescio
+
+USING: tools.testest kernel math ;
+IN: tests
+
+: wont-compile ;
+
+: run-tests ( -- )
+
+"Compilation error" describe#{
+  "Compilation error in user code" it#{
+     <{ wont-compile -> }>
+  }#
+}#
+;
+
+MAIN: run-tests

--- a/test/test-effect-error.expected
+++ b/test/test-effect-error.expected
@@ -1,0 +1,18 @@
+
+<DESCRIBE::>Compilation error
+
+<IT::>Compilation error in user code
+
+==== test-effect-error.factor
+
+test-effect-error.factor: 6
+
+Asset: wont-infer
+
+Stack effect declaration is wrong
+inferred ( -- x )
+declared ( -- )
+
+<COMPLETEDIN::>0.345100 ms
+
+<COMPLETEDIN::>0.516400 ms

--- a/test/test-effect-error.factor
+++ b/test/test-effect-error.factor
@@ -1,0 +1,17 @@
+! Copyright 2024 nomennescio
+
+USING: tools.testest kernel math ;
+IN: tests
+
+: wont-infer ( -- ) 0 ;
+
+: run-tests ( -- )
+
+"Compilation error" describe#{
+  "Compilation error in user code" it#{
+     <{ wont-infer -> }>
+  }#
+}#
+;
+
+MAIN: run-tests


### PR DESCRIPTION
Until now compiler errors that were triggered "late" resulted in "runtime" exceptions with unnecessary hard to read error messages. Now regular error messages will be displayed. The user is expected to fix all compilation errors before tests are going to be executed.