### PR TITLE
Remove deprecated 'lf' word.

### DIFF
--- a/test/test-custom.factor
+++ b/test/test-custom.factor
@@ -1,11 +1,11 @@
-! Copyright 2019-2022 nomennescio
+! Copyright 2019-2024 nomennescio
 
 USING: accessors debugger io kernel namespaces prettyprint sequences tools.testest ;
 IN: tests
 
 M: assert-sequence error.
   [ "Actually expected :" write expected>> ... ]
-  [ lf "but instead got :" write got>> ... ] bi
+  [ nl "but instead got :" write got>> ... ] bi
 ;
 
 : run-test ( -- )

--- a/tools/testest/testest.factor
+++ b/tools/testest/testest.factor
@@ -60,9 +60,6 @@ SYNTAX: <{ \ -> parse-until >quotation suffix! \ }> parse-until >quotation suffi
 
 ! customized printing
 
-! deprecated
-: lf ( -- ) "<:LF:>" write ;
-
 <PRIVATE
 
 : pprint-unlimited ( obj -- ) [ pprint ] without-limits ;


### PR DESCRIPTION
As far as I know, it is not being used by any code using the test framework, but in case it is, I will need to revert.